### PR TITLE
Use PRIuPTR instead of SIZE_T_FMT_CHAR

### DIFF
--- a/packcc.c
+++ b/packcc.c
@@ -41,10 +41,7 @@
 #endif
 #endif
 
-#ifndef SIZE_T_FMT_CHAR
-#define SIZE_T_FMT_CHAR "z"
-#endif
-
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -2114,17 +2111,17 @@ static code_reach_t generate_matching_string_code(generate_t *gen, const char *v
             write_characters(gen->stream, ' ', indent);
             fputs("if (\n", gen->stream);
             write_characters(gen->stream, ' ', indent + 4);
-            fprintf(gen->stream, "pcc_refill_buffer(ctx, %" SIZE_T_FMT_CHAR "u) < %" SIZE_T_FMT_CHAR "u ||\n", n, n);
+            fprintf(gen->stream, "pcc_refill_buffer(ctx, %" PRIuPTR ") < %" PRIuPTR " ||\n", n, n);
             for (i = 0; i < n - 1; i++) {
                 write_characters(gen->stream, ' ', indent + 4);
-                fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" SIZE_T_FMT_CHAR "u] != '%s' ||\n", i, escape_character(value[i], &s));
+                fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" PRIuPTR "] != '%s' ||\n", i, escape_character(value[i], &s));
             }
             write_characters(gen->stream, ' ', indent + 4);
-            fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" SIZE_T_FMT_CHAR "u] != '%s'\n", i, escape_character(value[i], &s));
+            fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" PRIuPTR "] != '%s'\n", i, escape_character(value[i], &s));
             write_characters(gen->stream, ' ', indent);
             fprintf(gen->stream, ") goto L%04d;\n", onfail);
             write_characters(gen->stream, ' ', indent);
-            fprintf(gen->stream, "ctx->pos += %" SIZE_T_FMT_CHAR "u;\n", n);
+            fprintf(gen->stream, "ctx->pos += %" PRIuPTR ";\n", n);
             if (!bare) {
                 indent -= 4;
                 write_characters(gen->stream, ' ', indent);


### PR DESCRIPTION
This replaces the commit b728b1ec671cf83d070acf7014c20c1609a8a03d.
Use a standard definition instead of our own definition.

See: https://github.com/universal-ctags/ctags/pull/2441, https://github.com/universal-ctags/ctags/pull/2444.